### PR TITLE
feat: add IStrategyAdapter interface for strategy adapters

### DIFF
--- a/contracts-foundry/src/interfaces/IStrategyAdapter.sol
+++ b/contracts-foundry/src/interfaces/IStrategyAdapter.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title IStrategyAdapter
+ * @author CrossMind Team
+ * @notice Interface for DeFi protocol adapters used in CrossMind strategies
+ * @dev All adapters (Aave, Lido, Curve, etc.) must implement this interface
+ */
+interface IStrategyAdapter {
+    /**
+     * @notice Invests funds into the underlying protocol
+     * @dev The adapter must implement the logic to supply tokens into the protocol
+     * @param amount Amount of tokens to invest
+     * @param token Address of the token to invest
+     * @return success Boolean indicating if the investment was successful
+     */
+    function invest(
+        uint256 amount,
+        address token
+    ) external payable returns (bool success);
+
+    /**
+     * @notice Withdraws funds from the underlying protocol
+     * @dev The adapter must implement the logic to withdraw tokens from the protocol
+     * @param amount Amount of tokens to withdraw
+     * @param token Address of the token to withdraw
+     * @return success Boolean indicating if the withdrawal was successful
+     */
+    function withdraw(
+        uint256 amount,
+        address token
+    ) external returns (bool success);
+}


### PR DESCRIPTION
- Add `IStrategyAdapter` interface to define the standard functions for strategy adapters.
- Each adapter must implement:
  - `invest(uint256 amount, address token)`
  - `withdraw(uint256 amount, address token)`
- This interface will be used by `AdapterRegistry` and different protocol adapters (Aave, Lido, Curve, etc.)
- No logic included — only interface definition.
